### PR TITLE
Changed pSync array to allocate _SHMEM_BARRIER_SYNC_SIZE elements, to…

### DIFF
--- a/verifier/sync/osh_sync_tc4.c
+++ b/verifier/sync/osh_sync_tc4.c
@@ -43,7 +43,7 @@ int osh_sync_tc4(const TE_NODE *node, int argc, const char *argv[])
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(argv);
 
-    pSync = shmalloc(sizeof(*pSync) * _SHMEM_BCAST_SYNC_SIZE);
+    pSync = shmalloc(sizeof(*pSync) * _SHMEM_BARRIER_SYNC_SIZE);
     if (!pSync)
     {
         rc = TC_SETUP_FAIL;


### PR DESCRIPTION
… fix shmem_free run-time error caused by using _SHMEM_BCAST_SYNC_SIZE (i.e too few) elements.