### PR TITLE
SHMEM_HEAP_TYPE -> SHMEM_SYMMETRIC_HEAP_ALLOCATOR

### DIFF
--- a/verifier/basic/osh_basic_tc3.c
+++ b/verifier/basic/osh_basic_tc3.c
@@ -50,7 +50,7 @@ static int memheap_type(void)
     if (memheap_type != MEMHEAP_ALLOC_UNKNOWN)
         return memheap_type;
 
-    p = getenv("SHMEM_HEAP_TYPE");
+    p = getenv("SHMEM_SYMMETRIC_HEAP_ALLOCATOR");
     if (p)
     {
         log_debug(OSH_TC, "heap allocator is %s\n", p);


### PR DESCRIPTION
Replace SHMEM_HEAP_TYPE constant with SHMEM_SYMMETRIC_HEAP_ALLOCATOR environment variable supported by OMPI.