### PR TITLE
fixes opal_progress check

### DIFF
--- a/verifier/configure.ac
+++ b/verifier/configure.ac
@@ -19,7 +19,10 @@ else
     CFLAGS="$CFLAGS -Wundef"
 fi
 
-AC_CHECK_LIB(oshmem, opal_progress, [CFLAGS="$CFLAGS -DHAVE_OPAL_PROGRESS"],
+AC_CHECK_LIB(open-pal, opal_progress, [
+                 CFLAGS="$CFLAGS -DHAVE_OPAL_PROGRESS"
+                 LDFLAGS="-lopen-pal $LDFLAGS"
+                 ],
 			     [AC_MSG_WARN([opal_progress() not found. Some OpenMPI/SHMEM versions require it in data suite.])])
 
 dnl Check oshmem version


### PR DESCRIPTION
@miked-mellanox @alinask @yosefe
call to opal progress is needed to speedup things up when hardware
one sided put/get/amos are emulated in software.
For example MXM UD transport

Signed-off-by: Alex Mikheev <alexm@mellanox.com>