### PR TITLE
Make do_progress a static inline for -O0

### DIFF
--- a/verifier/cmn/osh_cmn.h
+++ b/verifier/cmn/osh_cmn.h
@@ -311,7 +311,7 @@ enum{
     PUT_COMPLETED
 };
 
-inline void do_progress(void)
+static inline void do_progress(void)
 {
 #if defined(HAVE_OPAL_PROGRESS)
 	extern void opal_progress(void);


### PR DESCRIPTION
If disabling compiler optimizations with '-O0', clang and gcc report 'do_progress' as an undefined symbol - presumably because it's defined as inline, resulting in no external linkability.  Prepending
'static' fixes this.