### PR TITLE
Fix strided indices and psync sizes in alltoalls tests

### DIFF
--- a/verifier/coll/osh_coll_tc12.c
+++ b/verifier/coll/osh_coll_tc12.c
@@ -47,7 +47,7 @@ int osh_coll_tc12(const TE_NODE *node, int argc, const char *argv[])
 
     if (rc == TC_PASS)
     {
-        pSync = shmalloc(sizeof(*pSync) * SHMEM_ALLTOALL_SYNC_SIZE);
+        pSync = shmalloc(sizeof(*pSync) * SHMEM_ALLTOALLS_SYNC_SIZE);
         if (!pSync)
         {
             rc = TC_SETUP_FAIL;
@@ -129,13 +129,13 @@ static int test_item1(void)
     /* assign source values */
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
-            source[(pe * count * sst) + i] = my_proc + i;
-            dest[(pe * count * dst) + i] = 9999;
+            source[(pe * count * sst) + (i * sst)] = my_proc + i;
+            dest[(pe * count * dst) + (i * dst)] = 9999;
         }
     }
 
     /* This guarantees that PE set initial value before peer change one */
-    for ( i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++ )
+    for ( i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++ )
     {
         pSync[i] = _SHMEM_SYNC_VALUE;
     }
@@ -147,10 +147,10 @@ static int test_item1(void)
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
             expect_value = i + index_to_pe(pe, 0, 0, num_proc);
-            if (dest[(pe * count * dst) + i] != expect_value) {
+            if (dest[(pe * count * dst) + (i * dst)] != expect_value) {
                 rc = TC_FAIL;
                 log_debug(OSH_TC, "my#%d ERROR: dest[%d]=%ld, should be %d\n",
-                        my_proc, (pe * count * dst) + i, dest[(pe * count * dst) + i],
+                        my_proc, (pe * count * dst) + (i * dst), dest[(pe * count * dst) + (i * dst)],
                         expect_value);
             }
         }
@@ -184,13 +184,13 @@ static int test_item2(void)
     /* assign source values */
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
-            source[(pe * count * sst) + i] = my_proc + i;
-            dest[(pe * count * dst) + i] = 9999;
+            source[(pe * count * sst) + (i * sst)] = my_proc + i;
+            dest[(pe * count * dst) + (i * dst)] = 9999;
         }
     }
 
     /* This guarantees that PE set initial value before peer change one */
-    for ( i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++ )
+    for ( i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++ )
     {
         pSync[i] = _SHMEM_SYNC_VALUE;
     }
@@ -202,10 +202,10 @@ static int test_item2(void)
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
             expect_value = i + index_to_pe(pe, 0, 0, num_proc);
-            if (dest[(pe * count * dst) + i] != expect_value) {
+            if (dest[(pe * count * dst) + (i * dst)] != expect_value) {
                 rc = TC_FAIL;
                 log_debug(OSH_TC, "my#%d ERROR: dest[%d]=%ld, should be %d\n",
-                        my_proc, (pe * count * dst) + i, dest[(pe * count * dst) + i],
+                        my_proc, (pe * count * dst) + (i * dst), dest[(pe * count * dst) + (i * dst)],
                         expect_value);
             }
         }
@@ -238,13 +238,13 @@ static int test_item3(void)
     /* assign source values */
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
-            source[(pe * count * sst) + i] = my_proc + i;
-            dest[(pe * count * dst) + i] = 9999;
+            source[(pe * count * sst) + (i * sst)] = my_proc + i;
+            dest[(pe * count * dst) + (i * dst)] = 9999;
         }
     }
 
     /* This guarantees that PE set initial value before peer change one */
-    for ( i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++ )
+    for ( i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++ )
     {
         pSync[i] = _SHMEM_SYNC_VALUE;
     }
@@ -256,10 +256,10 @@ static int test_item3(void)
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
             expect_value = i + index_to_pe(pe, 0, 0, num_proc);
-            if (dest[(pe * count * dst) + i] != expect_value) {
+            if (dest[(pe * count * dst) + (i * dst)] != expect_value) {
                 rc = TC_FAIL;
                 log_debug(OSH_TC, "my#%d ERROR: dest[%d]=%ld, should be %d\n",
-                        my_proc, (pe * count * dst) + i, dest[(pe * count * dst) + i],
+                        my_proc, (pe * count * dst) + (i * dst), dest[(pe * count * dst) + (i * dst)],
                         expect_value);
             }
         }
@@ -293,13 +293,13 @@ static int test_item4(void)
     /* assign source values */
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
-            source[(pe * count * sst) + i] = my_proc + i;
-            dest[(pe * count * dst) + i] = 9999;
+            source[(pe * count * sst) + (i * sst)] = my_proc + i;
+            dest[(pe * count * dst) + (i * dst)] = 9999;
         }
     }
 
     /* This guarantees that PE set initial value before peer change one */
-    for ( i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++ )
+    for ( i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++ )
     {
         pSync[i] = _SHMEM_SYNC_VALUE;
     }
@@ -311,10 +311,10 @@ static int test_item4(void)
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
             expect_value = i + index_to_pe(pe, 0, 0, num_proc);
-            if (dest[(pe * count * dst) + i] != expect_value) {
+            if (dest[(pe * count * dst) + (i * dst)] != expect_value) {
                 rc = TC_FAIL;
                 log_debug(OSH_TC, "my#%d ERROR: dest[%d]=%ld, should be %d\n",
-                        my_proc, (pe * count * dst) + i, dest[(pe * count * dst) + i],
+                        my_proc, (pe * count * dst) + (i * dst), dest[(pe * count * dst) + (i * dst)],
                         expect_value);
             }
         }
@@ -347,13 +347,13 @@ static int test_item5(void)
     /* assign source values */
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
-            source[(pe * count * sst) + i] = my_proc + i;
-            dest[(pe * count * dst) + i] = 9999;
+            source[(pe * count * sst) + (i * sst)] = my_proc + i;
+            dest[(pe * count * dst) + (i * dst)] = 9999;
         }
     }
 
     /* This guarantees that PE set initial value before peer change one */
-    for ( i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++ )
+    for ( i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++ )
     {
         pSync[i] = _SHMEM_SYNC_VALUE;
     }
@@ -365,10 +365,10 @@ static int test_item5(void)
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
             expect_value = i + index_to_pe(pe, 0, 0, num_proc);
-            if (dest[(pe * count * dst) + i] != expect_value) {
+            if (dest[(pe * count * dst) + (i * dst)] != expect_value) {
                 rc = TC_FAIL;
                 log_debug(OSH_TC, "my#%d ERROR: dest[%d]=%ld, should be %d\n",
-                        my_proc, (pe * count * dst) + i, dest[(pe * count * dst) + i],
+                        my_proc, (pe * count * dst) + (i * dst), dest[(pe * count * dst) + (i * dst)],
                         expect_value);
             }
         }
@@ -402,13 +402,13 @@ static int test_item6(void)
     /* assign source values */
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
-            source[(pe * count * sst) + i] = my_proc + i;
-            dest[(pe * count * dst) + i] = 9999;
+            source[(pe * count * sst) + (i * sst)] = my_proc + i;
+            dest[(pe * count * dst) + (i * dst)] = 9999;
         }
     }
 
     /* This guarantees that PE set initial value before peer change one */
-    for ( i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++ )
+    for ( i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++ )
     {
         pSync[i] = _SHMEM_SYNC_VALUE;
     }
@@ -420,10 +420,10 @@ static int test_item6(void)
     for (pe = 0; pe < num_proc; pe++) {
         for (i = 0; i < count; i++) {
             expect_value = i + index_to_pe(pe, 0, 0, num_proc);
-            if (dest[(pe * count * dst) + i] != expect_value) {
+            if (dest[(pe * count * dst) + (i * dst)] != expect_value) {
                 rc = TC_FAIL;
                 log_debug(OSH_TC, "my#%d ERROR: dest[%d]=%ld, should be %d\n",
-                        my_proc, (pe * count * dst) + i, dest[(pe * count * dst) + i],
+                        my_proc, (pe * count * dst) + (i * dst), dest[(pe * count * dst) + (i * dst)],
                         expect_value);
             }
         }

--- a/verifier/coll/osh_coll_tc12.c
+++ b/verifier/coll/osh_coll_tc12.c
@@ -15,6 +15,10 @@
 
 #include "osh_coll_tests.h"
 
+#ifndef SHMEM_ALLTOALLS_SYNC_SIZE
+#define SHMEM_ALLTOALLS_SYNC_SIZE SHMEM_ALLTOALL_SYNC_SIZE
+#endif
+
 /****************************************************************************
  * Test Case can consists of different number of separate items
  * it is recommended to form every item as function


### PR DESCRIPTION
Change the initialization of source and dest buffers to include the
stride being tested (and update the verification and log).  Also change
instances of SHMEM_ALLTOALL_SYNC_SIZE to SHMEM_ALLTOALLS_SYNC_SIZE.