### PR TITLE
Add --enable-quick-tests option to optionally speed up tests

### DIFF
--- a/verifier/atomic/osh_atomic_tc1.c
+++ b/verifier/atomic/osh_atomic_tc1.c
@@ -27,7 +27,11 @@ static int test_item3(void);
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_swap
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc10.c
+++ b/verifier/atomic/osh_atomic_tc10.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_fadd
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc11.c
+++ b/verifier/atomic/osh_atomic_tc11.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_fadd
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc12.c
+++ b/verifier/atomic/osh_atomic_tc12.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_fadd
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc13.c
+++ b/verifier/atomic/osh_atomic_tc13.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_finc
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc14.c
+++ b/verifier/atomic/osh_atomic_tc14.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_finc
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc15.c
+++ b/verifier/atomic/osh_atomic_tc15.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_finc
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc16.c
+++ b/verifier/atomic/osh_atomic_tc16.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_add
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc17.c
+++ b/verifier/atomic/osh_atomic_tc17.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_add
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc18.c
+++ b/verifier/atomic/osh_atomic_tc18.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_add
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc19.c
+++ b/verifier/atomic/osh_atomic_tc19.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_inc
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc2.c
+++ b/verifier/atomic/osh_atomic_tc2.c
@@ -27,7 +27,11 @@ static int test_item3(void);
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_swap
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc20.c
+++ b/verifier/atomic/osh_atomic_tc20.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_inc
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc21.c
+++ b/verifier/atomic/osh_atomic_tc21.c
@@ -24,11 +24,19 @@ static int test_item2(void);
 static int test_item3(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_inc
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc22.c
+++ b/verifier/atomic/osh_atomic_tc22.c
@@ -21,7 +21,11 @@
  ***************************************************************************/
 static int test_item1(void);
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 30
+#else
 #define COUNT_VALUE 300
+#endif
 #define CHECK_COUNT_VALUE 1
 
 /****************************************************************************

--- a/verifier/atomic/osh_atomic_tc3.c
+++ b/verifier/atomic/osh_atomic_tc3.c
@@ -37,7 +37,11 @@ static int test_item2(void) {return TC_PASS;}
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_swap
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 #if !defined(SKIP)
 static long __cycle_count = COUNT_VALUE;

--- a/verifier/atomic/osh_atomic_tc4.c
+++ b/verifier/atomic/osh_atomic_tc4.c
@@ -27,7 +27,11 @@ static int test_item3(void);
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_swap
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc5.c
+++ b/verifier/atomic/osh_atomic_tc5.c
@@ -27,7 +27,11 @@ static int test_item3(void);
 #define TYPE_VALUE  float
 #define FUNC_VALUE  shmem_float_swap
 #define DEFAULT_VALUE  (-1.0)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc6.c
+++ b/verifier/atomic/osh_atomic_tc6.c
@@ -27,7 +27,11 @@ static int test_item3(void);
 #define TYPE_VALUE  double
 #define FUNC_VALUE  shmem_double_swap
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc7.c
+++ b/verifier/atomic/osh_atomic_tc7.c
@@ -27,7 +27,11 @@ static int test_item3(void);
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_cswap
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc8.c
+++ b/verifier/atomic/osh_atomic_tc8.c
@@ -27,7 +27,11 @@ static int test_item3(void);
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_cswap
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/atomic/osh_atomic_tc9.c
+++ b/verifier/atomic/osh_atomic_tc9.c
@@ -27,7 +27,11 @@ static int test_item3(void);
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_cswap
 #define DEFAULT_VALUE  (-1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 
 static long __cycle_count = COUNT_VALUE;
 

--- a/verifier/basic/osh_basic_tc2.c
+++ b/verifier/basic/osh_basic_tc2.c
@@ -26,7 +26,11 @@ static int test_shmem_ptr(void);
 static int test_shmem_accessible(void);
 
 
+#ifdef QUICK_TEST
+#define LOOP_COUNT  100
+#else
 #define LOOP_COUNT  1000
+#endif
 
 
 /****************************************************************************

--- a/verifier/basic/osh_basic_tc3.c
+++ b/verifier/basic/osh_basic_tc3.c
@@ -33,7 +33,11 @@ static int test_allocation_size(void);
 static int test_global_vars(void);
 static int test_max_size(void);
 
+#ifdef QUICK_TEST
+#define LOOP_COUNT  100
+#else
 #define LOOP_COUNT  1000
+#endif
 
 enum {
     MEMHEAP_ALLOC_UNKNOWN,

--- a/verifier/basic/osh_basic_tc4.c
+++ b/verifier/basic/osh_basic_tc4.c
@@ -22,7 +22,11 @@
 static int test_item1(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 
 
 /****************************************************************************

--- a/verifier/basic/osh_basic_tc5.c
+++ b/verifier/basic/osh_basic_tc5.c
@@ -15,6 +15,10 @@
 
 #include "osh_basic_tests.h"
 
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdlib.h>
+
 /****************************************************************************
  * Test Case can consitis of different number of separate items
  * it is recommended to form every item as function
@@ -22,7 +26,11 @@
 static int test_item1(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 
 
 /****************************************************************************

--- a/verifier/basic/osh_basic_tc8.c
+++ b/verifier/basic/osh_basic_tc8.c
@@ -12,8 +12,13 @@
 #include "rnd_mt.h"
 #include "osh_basic_tests.h"
 
+#ifdef QUICK_TEST
+#define TABLE_LENGTH                        (10)
+#define ITERATIONS_CONST                    (2)
+#else
 #define TABLE_LENGTH                        (100)
 #define ITERATIONS_CONST                    (10)
+#endif
 #define PRETEST_CONST                       (4)
 #define POTENTIAL_MAX_SIZE(heap_size)       (heap_size/2)
 #define SHMEMALIGN_BOUNDRY                  (2)
@@ -142,6 +147,8 @@ static int stressing_shmalloc_test (void)
      * In the assumption, that smalloc can allocate memory that
      * is greater than set in environment variable by an user.
      */
+    printf("max_possible_alloc = %ld\n", max_possible_alloc);
+    printf("heap_size = %ld\n", heap_size);
     if (max_possible_alloc < heap_size) {
 #endif
         log_error(OSH_TC, "Maximum allocation size is %ld . exiting...\n",

--- a/verifier/coll/osh_coll_tc1.c
+++ b/verifier/coll/osh_coll_tc1.c
@@ -42,7 +42,11 @@ static int test_item7(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/coll/osh_coll_tc10.c
+++ b/verifier/coll/osh_coll_tc10.c
@@ -42,7 +42,11 @@ static int test_item7(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/coll/osh_coll_tc2.c
+++ b/verifier/coll/osh_coll_tc2.c
@@ -42,7 +42,11 @@ static int test_item7(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/coll/osh_coll_tc4.c
+++ b/verifier/coll/osh_coll_tc4.c
@@ -28,7 +28,11 @@ static int test_item6(void);
 static int test_item7(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int32_t
 #define FUNC_VALUE  shmem_collect32
 #define SIZE_VALUE  sizeof(TYPE_VALUE)

--- a/verifier/coll/osh_coll_tc5.c
+++ b/verifier/coll/osh_coll_tc5.c
@@ -27,7 +27,11 @@ static int test_item5(void);
 static int test_item6(void);
 static int test_item7(void);
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int64_t
 #define FUNC_VALUE  shmem_collect64
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -41,7 +45,11 @@ static int test_item7(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/coll/osh_coll_tc6.c
+++ b/verifier/coll/osh_coll_tc6.c
@@ -27,7 +27,11 @@ static int test_item5(void);
 static int test_item6(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int32_t
 #define FUNC_VALUE  shmem_fcollect32
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -41,7 +45,11 @@ static int test_item6(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/coll/osh_coll_tc7.c
+++ b/verifier/coll/osh_coll_tc7.c
@@ -27,7 +27,11 @@ static int test_item5(void);
 static int test_item6(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int64_t
 #define FUNC_VALUE  shmem_fcollect64
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -41,7 +45,11 @@ static int test_item6(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/configure.ac
+++ b/verifier/configure.ac
@@ -39,5 +39,11 @@ AC_CHECK_DECLS([shmem_alltoall32, shmem_alltoall64],
     ],
     [AM_CONDITIONAL([HAVE_ALLTOALL],[false])], [#include "shmem.h"])
 
+AC_ARG_ENABLE([quick-tests],
+    [AC_HELP_STRING([--enable-quick-tests],
+    [Enable faster tests with fewer iterations/operations (default: disabled)])])
+AS_IF([test "$enable_quick_tests" = "yes"], [AC_DEFINE([QUICK_TEST], [1], [Enable quick tests])], [])
+AM_CONDITIONAL([QUICK_TEST], [test "$enable_quick_tests" = "yes"])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/verifier/data/osh_data_tc1.c
+++ b/verifier/data/osh_data_tc1.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_short_g
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   (((unsigned long long)1 << ( 8 * SIZE_VALUE - 1)) - 1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc10.c
+++ b/verifier/data/osh_data_tc10.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_long_p
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   (((unsigned long long)1 << ( 8 * SIZE_VALUE - 1)) - 1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc11.c
+++ b/verifier/data/osh_data_tc11.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_float_p
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   FLT_MAX
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc12.c
+++ b/verifier/data/osh_data_tc12.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_double_p
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   DBL_MAX
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc13.c
+++ b/verifier/data/osh_data_tc13.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_longlong_p
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   (((unsigned long long)1 << ( 8 * SIZE_VALUE - 1)) - 1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc14.c
+++ b/verifier/data/osh_data_tc14.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_longdouble_p
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   LDBL_MAX
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc15.c
+++ b/verifier/data/osh_data_tc15.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc16.c
+++ b/verifier/data/osh_data_tc16.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc17.c
+++ b/verifier/data/osh_data_tc17.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc18.c
+++ b/verifier/data/osh_data_tc18.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc19.c
+++ b/verifier/data/osh_data_tc19.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc2.c
+++ b/verifier/data/osh_data_tc2.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_int_g
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   (((unsigned long long)1 << ( 8 * SIZE_VALUE - 1)) - 1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc20.c
+++ b/verifier/data/osh_data_tc20.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc21.c
+++ b/verifier/data/osh_data_tc21.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc22.c
+++ b/verifier/data/osh_data_tc22.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc23.c
+++ b/verifier/data/osh_data_tc23.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc24.c
+++ b/verifier/data/osh_data_tc24.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc25.c
+++ b/verifier/data/osh_data_tc25.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc26.c
+++ b/verifier/data/osh_data_tc26.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc27.c
+++ b/verifier/data/osh_data_tc27.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc28.c
+++ b/verifier/data/osh_data_tc28.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc29.c
+++ b/verifier/data/osh_data_tc29.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc3.c
+++ b/verifier/data/osh_data_tc3.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_long_g
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   (((unsigned long long)1 << ( 8 * SIZE_VALUE - 1)) - 1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc30.c
+++ b/verifier/data/osh_data_tc30.c
@@ -38,7 +38,11 @@ static int test_item5(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc31.c
+++ b/verifier/data/osh_data_tc31.c
@@ -43,7 +43,11 @@ static int test_item6(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc32.c
+++ b/verifier/data/osh_data_tc32.c
@@ -43,7 +43,11 @@ static int test_item6(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc33.c
+++ b/verifier/data/osh_data_tc33.c
@@ -37,7 +37,11 @@ static int test_item4(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc34.c
+++ b/verifier/data/osh_data_tc34.c
@@ -37,7 +37,11 @@ static int test_item4(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc35.c
+++ b/verifier/data/osh_data_tc35.c
@@ -37,7 +37,11 @@ static int test_item4(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc36.c
+++ b/verifier/data/osh_data_tc36.c
@@ -37,7 +37,11 @@ static int test_item4(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc37.c
+++ b/verifier/data/osh_data_tc37.c
@@ -37,7 +37,11 @@ static int test_item4(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc38.c
+++ b/verifier/data/osh_data_tc38.c
@@ -37,7 +37,11 @@ static int test_item4(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/data/osh_data_tc4.c
+++ b/verifier/data/osh_data_tc4.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_float_g
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   FLT_MAX
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc40.c
+++ b/verifier/data/osh_data_tc40.c
@@ -28,7 +28,11 @@ static int test_item5(void);
 static int test_item6(void);
 
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE		1000
+#else
 #define COUNT_VALUE		100000
+#endif
 #define BUFFER_COUNT	0x1000
 #define SHMEM_SYNC_INVALID 	(-77)
 

--- a/verifier/data/osh_data_tc5.c
+++ b/verifier/data/osh_data_tc5.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_double_g
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   DBL_MAX
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc6.c
+++ b/verifier/data/osh_data_tc6.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_longlong_g
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   (((unsigned long long)1 << ( 8 * SIZE_VALUE - 1)) - 1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc7.c
+++ b/verifier/data/osh_data_tc7.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_longdouble_g
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   LDBL_MAX
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc8.c
+++ b/verifier/data/osh_data_tc8.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_short_p
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   (((unsigned long long)1 << ( 8 * SIZE_VALUE - 1)) - 1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/data/osh_data_tc9.c
+++ b/verifier/data/osh_data_tc9.c
@@ -29,7 +29,11 @@ static int test_item3(void);
 #define FUNC_VALUE  shmem_int_p
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
 #define MAX_VALUE   (((unsigned long long)1 << ( 8 * SIZE_VALUE - 1)) - 1)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define STEP_VALUE  (MAX_VALUE / COUNT_VALUE)
 
 

--- a/verifier/nbi/osh_nbi_tc1.c
+++ b/verifier/nbi/osh_nbi_tc1.c
@@ -23,7 +23,11 @@
  ***************************************************************************/
 static int test_item1(void);
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  unsigned char
 #define FUNC_VALUE  shmem_getmem_nbi
 #define SIZE_VALUE  sizeof(TYPE_VALUE)

--- a/verifier/nbi/osh_nbi_tc2.c
+++ b/verifier/nbi/osh_nbi_tc2.c
@@ -22,7 +22,11 @@
  ***************************************************************************/
 static int test_item1(void);
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  unsigned char
 #define FUNC_VALUE  shmem_putmem_nbi
 #define SIZE_VALUE  sizeof(TYPE_VALUE)

--- a/verifier/reduce/osh_reduce_tc1.c
+++ b/verifier/reduce/osh_reduce_tc1.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  short
 #define FUNC_VALUE  shmem_short_and_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -44,7 +48,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc10.c
+++ b/verifier/reduce/osh_reduce_tc10.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_xor_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc11.c
+++ b/verifier/reduce/osh_reduce_tc11.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_xor_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc12.c
+++ b/verifier/reduce/osh_reduce_tc12.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_xor_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc13.c
+++ b/verifier/reduce/osh_reduce_tc13.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  short
 #define FUNC_VALUE  shmem_short_max_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc14.c
+++ b/verifier/reduce/osh_reduce_tc14.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_max_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc15.c
+++ b/verifier/reduce/osh_reduce_tc15.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_max_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc16.c
+++ b/verifier/reduce/osh_reduce_tc16.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_max_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc17.c
+++ b/verifier/reduce/osh_reduce_tc17.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  float
 #define FUNC_VALUE  shmem_float_max_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc18.c
+++ b/verifier/reduce/osh_reduce_tc18.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  double
 #define FUNC_VALUE  shmem_double_max_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc19.c
+++ b/verifier/reduce/osh_reduce_tc19.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long double
 #define FUNC_VALUE  shmem_longdouble_max_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc2.c
+++ b/verifier/reduce/osh_reduce_tc2.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_and_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -44,7 +48,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc20.c
+++ b/verifier/reduce/osh_reduce_tc20.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  short
 #define FUNC_VALUE  shmem_short_min_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc21.c
+++ b/verifier/reduce/osh_reduce_tc21.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_min_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc22.c
+++ b/verifier/reduce/osh_reduce_tc22.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_min_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc23.c
+++ b/verifier/reduce/osh_reduce_tc23.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_min_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc24.c
+++ b/verifier/reduce/osh_reduce_tc24.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  float
 #define FUNC_VALUE  shmem_float_min_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc25.c
+++ b/verifier/reduce/osh_reduce_tc25.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  double
 #define FUNC_VALUE  shmem_double_min_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc26.c
+++ b/verifier/reduce/osh_reduce_tc26.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long double
 #define FUNC_VALUE  shmem_longdouble_min_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc27.c
+++ b/verifier/reduce/osh_reduce_tc27.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  short
 #define FUNC_VALUE  shmem_short_sum_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc28.c
+++ b/verifier/reduce/osh_reduce_tc28.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_sum_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc29.c
+++ b/verifier/reduce/osh_reduce_tc29.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_sum_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc3.c
+++ b/verifier/reduce/osh_reduce_tc3.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_and_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -44,7 +48,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc30.c
+++ b/verifier/reduce/osh_reduce_tc30.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_sum_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc31.c
+++ b/verifier/reduce/osh_reduce_tc31.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  float
 #define FUNC_VALUE  shmem_float_sum_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc32.c
+++ b/verifier/reduce/osh_reduce_tc32.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  double
 #define FUNC_VALUE  shmem_double_sum_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc33.c
+++ b/verifier/reduce/osh_reduce_tc33.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long double
 #define FUNC_VALUE  shmem_longdouble_sum_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc34.c
+++ b/verifier/reduce/osh_reduce_tc34.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  float complex
 #define FUNC_VALUE  shmem_complexf_sum_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc35.c
+++ b/verifier/reduce/osh_reduce_tc35.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  double complex
 #define FUNC_VALUE  shmem_complexd_sum_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -43,7 +47,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc36.c
+++ b/verifier/reduce/osh_reduce_tc36.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  short
 #define FUNC_VALUE  shmem_short_prod_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc37.c
+++ b/verifier/reduce/osh_reduce_tc37.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_prod_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc38.c
+++ b/verifier/reduce/osh_reduce_tc38.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_prod_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc39.c
+++ b/verifier/reduce/osh_reduce_tc39.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_prod_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc4.c
+++ b/verifier/reduce/osh_reduce_tc4.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_and_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -44,7 +48,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc40.c
+++ b/verifier/reduce/osh_reduce_tc40.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  float
 #define FUNC_VALUE  shmem_float_prod_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc41.c
+++ b/verifier/reduce/osh_reduce_tc41.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  double
 #define FUNC_VALUE  shmem_double_prod_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc42.c
+++ b/verifier/reduce/osh_reduce_tc42.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long double
 #define FUNC_VALUE  shmem_longdouble_prod_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc43.c
+++ b/verifier/reduce/osh_reduce_tc43.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  float complex
 #define FUNC_VALUE  shmem_complexf_prod_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc44.c
+++ b/verifier/reduce/osh_reduce_tc44.c
@@ -29,7 +29,11 @@ static int test_item7(void);
 static int test_item8(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  double complex
 #define FUNC_VALUE  shmem_complexd_prod_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item8(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc5.c
+++ b/verifier/reduce/osh_reduce_tc5.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  short
 #define FUNC_VALUE  shmem_short_or_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -44,7 +48,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc6.c
+++ b/verifier/reduce/osh_reduce_tc6.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_or_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -44,7 +48,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc7.c
+++ b/verifier/reduce/osh_reduce_tc7.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_or_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -44,7 +48,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc8.c
+++ b/verifier/reduce/osh_reduce_tc8.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_or_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -44,7 +48,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/reduce/osh_reduce_tc9.c
+++ b/verifier/reduce/osh_reduce_tc9.c
@@ -30,7 +30,11 @@ static int test_item8(void);
 static int test_item9(void);
 
 
+#ifdef QUICK_TEST
+#define WAIT_COUNT  1
+#else
 #define WAIT_COUNT  5
+#endif
 #define TYPE_VALUE  short
 #define FUNC_VALUE  shmem_short_xor_to_all
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
@@ -45,7 +49,11 @@ static int test_item9(void);
  */
 static int __parse_opt( const TE_NODE *, int, const char ** );
 
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_BUFFER_SIZE 8096
 
 static long __max_buffer_size = MAX_BUFFER_SIZE;

--- a/verifier/strided/osh_strided_tc1.c
+++ b/verifier/strided/osh_strided_tc1.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  short
 #define FUNC_VALUE  shmem_short_iget
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 

--- a/verifier/strided/osh_strided_tc10.c
+++ b/verifier/strided/osh_strided_tc10.c
@@ -26,7 +26,11 @@ static int test_item1(void);
 #define TYPE_VALUE DATA128_TYPE
 #define FUNC_VALUE  shmem_iget128
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 /****************************************************************************

--- a/verifier/strided/osh_strided_tc11.c
+++ b/verifier/strided/osh_strided_tc11.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  short
 #define FUNC_VALUE  shmem_short_iput
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5
 

--- a/verifier/strided/osh_strided_tc12.c
+++ b/verifier/strided/osh_strided_tc12.c
@@ -26,7 +26,11 @@ static int test_item1(void);
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_iput
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5 //seconds to wait
 

--- a/verifier/strided/osh_strided_tc13.c
+++ b/verifier/strided/osh_strided_tc13.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_iput
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5 //seconds to wait
 

--- a/verifier/strided/osh_strided_tc14.c
+++ b/verifier/strided/osh_strided_tc14.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  float
 #define FUNC_VALUE  shmem_float_iput
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5 //seconds to wait
 

--- a/verifier/strided/osh_strided_tc15.c
+++ b/verifier/strided/osh_strided_tc15.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  double
 #define FUNC_VALUE  shmem_double_iput
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5 //seconds to wait
 

--- a/verifier/strided/osh_strided_tc16.c
+++ b/verifier/strided/osh_strided_tc16.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_iput
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5 //seconds to wait
 

--- a/verifier/strided/osh_strided_tc17.c
+++ b/verifier/strided/osh_strided_tc17.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  long double
 #define FUNC_VALUE  shmem_longdouble_iput
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5 //seconds to wait
 

--- a/verifier/strided/osh_strided_tc18.c
+++ b/verifier/strided/osh_strided_tc18.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  uint32_t
 #define FUNC_VALUE  shmem_iput32
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5 //seconds to wait
 

--- a/verifier/strided/osh_strided_tc19.c
+++ b/verifier/strided/osh_strided_tc19.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  uint64_t
 #define FUNC_VALUE  shmem_iput64
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5 //seconds to wait
 

--- a/verifier/strided/osh_strided_tc2.c
+++ b/verifier/strided/osh_strided_tc2.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  int
 #define FUNC_VALUE  shmem_int_iget
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 

--- a/verifier/strided/osh_strided_tc20.c
+++ b/verifier/strided/osh_strided_tc20.c
@@ -28,7 +28,11 @@ static int test_item1(void);
 #define TYPE_VALUE  DATA128_TYPE
 #define FUNC_VALUE  shmem_iput128
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 #define WAIT_LIMIT 5 //seconds
 

--- a/verifier/strided/osh_strided_tc3.c
+++ b/verifier/strided/osh_strided_tc3.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  long
 #define FUNC_VALUE  shmem_long_iget
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 /****************************************************************************

--- a/verifier/strided/osh_strided_tc4.c
+++ b/verifier/strided/osh_strided_tc4.c
@@ -26,7 +26,11 @@ static int test_item1(void);
 #define TYPE_VALUE  float
 #define FUNC_VALUE  shmem_float_iget
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 

--- a/verifier/strided/osh_strided_tc5.c
+++ b/verifier/strided/osh_strided_tc5.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  double
 #define FUNC_VALUE  shmem_double_iget
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 

--- a/verifier/strided/osh_strided_tc6.c
+++ b/verifier/strided/osh_strided_tc6.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  long long
 #define FUNC_VALUE  shmem_longlong_iget
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 /****************************************************************************

--- a/verifier/strided/osh_strided_tc7.c
+++ b/verifier/strided/osh_strided_tc7.c
@@ -26,7 +26,11 @@ static int test_item1(void);
 #define TYPE_VALUE  long double
 #define FUNC_VALUE  shmem_longdouble_iget
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 /****************************************************************************

--- a/verifier/strided/osh_strided_tc8.c
+++ b/verifier/strided/osh_strided_tc8.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  uint32_t
 #define FUNC_VALUE  shmem_iget32
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 /****************************************************************************

--- a/verifier/strided/osh_strided_tc9.c
+++ b/verifier/strided/osh_strided_tc9.c
@@ -27,7 +27,11 @@ static int test_item1(void);
 #define TYPE_VALUE  uint64_t
 #define FUNC_VALUE  shmem_iget64
 #define SIZE_VALUE  sizeof(TYPE_VALUE)
+#ifdef QUICK_TEST
+#define COUNT_VALUE 10
+#else
 #define COUNT_VALUE 100
+#endif
 #define MAX_ARRAY_SIZE  1000
 
 


### PR DESCRIPTION
Uses "#ifdef QUICK_TEST" to reduce the number of iterations and/or the time spent waiting for communication operations to complete.  In particular, we need this in order for our Travis CI suite to include the Mellanox tests within the designated time limit.