### PR TITLE
Add option to call reductions with active set only

### DIFF
--- a/verifier/cmn/osh_cmn.c
+++ b/verifier/cmn/osh_cmn.c
@@ -430,3 +430,22 @@ unsigned long long memheap_size (void) {
     }
     return (size * factor);
 }
+
+int check_within_active_set(int PE_start, int logPE_stride, int PE_size, int my_pe, int num_pes)
+{
+#ifdef CHECK_ACTIVE_SET
+    int shmem_err_check_active_stride = 1 << logPE_stride;
+    if (PE_start < 0 || logPE_stride < 0 || PE_size < 0 || \
+        PE_start + (PE_size - 1) * shmem_err_check_active_stride > num_pes) {
+        return 0;
+    }
+    if (! (my_pe >= PE_start && \
+           my_pe <= PE_start + (PE_size-1) * shmem_err_check_active_stride && \
+           (my_pe - PE_start) % shmem_err_check_active_stride == 0)) {
+        return 0;
+    }
+    return 1;
+#else
+    return 1;
+#endif
+}

--- a/verifier/cmn/osh_cmn.c
+++ b/verifier/cmn/osh_cmn.c
@@ -435,13 +435,17 @@ int check_within_active_set(int PE_start, int logPE_stride, int PE_size, int my_
 {
 #ifdef CHECK_ACTIVE_SET
     int shmem_err_check_active_stride = 1 << logPE_stride;
-    if (PE_start < 0 || logPE_stride < 0 || PE_size < 0 || \
-        PE_start + (PE_size - 1) * shmem_err_check_active_stride > num_pes) {
+    if (logPE_stride >= sizeof(int) * 8 - 1) {
+        log_error(OSH_TC, "logPE_stride is too large\n");
         return 0;
     }
-    if (! (my_pe >= PE_start && \
-           my_pe <= PE_start + (PE_size-1) * shmem_err_check_active_stride && \
-           (my_pe - PE_start) % shmem_err_check_active_stride == 0)) {
+    if ((PE_start < 0) || (logPE_stride < 0) || (PE_size < 0) || \
+        (PE_start + (PE_size - 1) * shmem_err_check_active_stride > num_pes)) {
+        return 0;
+    }
+    if (! ((my_pe >= PE_start) && \
+           (my_pe <= PE_start + (PE_size-1) * shmem_err_check_active_stride) && \
+           ((my_pe - PE_start) % shmem_err_check_active_stride == 0))) {
         return 0;
     }
     return 1;

--- a/verifier/cmn/osh_cmn.h
+++ b/verifier/cmn/osh_cmn.h
@@ -356,5 +356,7 @@ static INLINE unsigned sys_log2(unsigned long long val)
 
     return count > 0 ? count - 1 : 0;
 }
+
+int check_within_active_set(int PE_start, int logPE_stride, int PE_size, int my_pe, int num_pes);
 #endif /* _OSH_CMN_H_ */
 

--- a/verifier/configure.ac
+++ b/verifier/configure.ac
@@ -39,5 +39,11 @@ AC_CHECK_DECLS([shmem_alltoall32, shmem_alltoall64],
     ],
     [AM_CONDITIONAL([HAVE_ALLTOALL],[false])], [#include "shmem.h"])
 
+AC_ARG_ENABLE([active-sets],
+    [AC_HELP_STRING([--enable-active-sets],
+    [Enable checking whether PEs are within the active set before calling reductions (default: disabled)])])
+AS_IF([test "$enable_active_sets" = "yes"], [AC_DEFINE([CHECK_ACTIVE_SET], [1], [Enable active set check])], [])
+AM_CONDITIONAL([CHECK_ACTIVE_SET], [test "$enable_active_sets" = "yes"])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/verifier/reduce/osh_reduce_tc1.c
+++ b/verifier/reduce/osh_reduce_tc1.c
@@ -787,8 +787,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                  /* Put value to peer */
+                  FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -806,23 +810,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                              my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -894,8 +899,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -913,23 +922,25 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -994,26 +1005,30 @@ static int test_item9(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc > 2 ? ((TYPE_VALUE)BASE_VALUE & (TYPE_VALUE)num_proc) : (TYPE_VALUE)BASE_VALUE ));
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc10.c
+++ b/verifier/reduce/osh_reduce_tc10.c
@@ -810,8 +810,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -829,23 +833,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -927,8 +932,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -946,23 +955,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -1037,26 +1047,30 @@ static int test_item9(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc11.c
+++ b/verifier/reduce/osh_reduce_tc11.c
@@ -810,8 +810,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -829,23 +833,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -927,8 +932,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -946,21 +955,23 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
 
                 shfree(pWrk);
@@ -1037,26 +1048,30 @@ static int test_item9(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc12.c
+++ b/verifier/reduce/osh_reduce_tc12.c
@@ -810,8 +810,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -829,23 +833,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -927,8 +932,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -946,23 +955,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -1037,26 +1047,30 @@ static int test_item9(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc13.c
+++ b/verifier/reduce/osh_reduce_tc13.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc % 2 ? num_proc - 1 : num_proc - 2) );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc14.c
+++ b/verifier/reduce/osh_reduce_tc14.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc % 2 ? num_proc - 1 : num_proc - 2) );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc15.c
+++ b/verifier/reduce/osh_reduce_tc15.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc % 2 ? num_proc - 1 : num_proc - 2) );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc16.c
+++ b/verifier/reduce/osh_reduce_tc16.c
@@ -776,8 +776,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -795,23 +799,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -890,26 +895,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc % 2 ? num_proc - 1 : num_proc - 2) );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc17.c
+++ b/verifier/reduce/osh_reduce_tc17.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc % 2 ? num_proc - 1 : num_proc - 2) );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc18.c
+++ b/verifier/reduce/osh_reduce_tc18.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc % 2 ? num_proc - 1 : num_proc - 2) );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc19.c
+++ b/verifier/reduce/osh_reduce_tc19.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc % 2 ? num_proc - 1 : num_proc - 2) );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const_longdouble(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const_longdouble(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc2.c
+++ b/verifier/reduce/osh_reduce_tc2.c
@@ -787,8 +787,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -806,23 +810,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -894,8 +899,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -913,23 +922,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -994,12 +1004,15 @@ static int test_item9(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc > 2 ? ((TYPE_VALUE)BASE_VALUE & (TYPE_VALUE)num_proc) : (TYPE_VALUE)BASE_VALUE ));
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
                 if (rc)
                 {
@@ -1014,6 +1027,7 @@ static int test_item9(void)
                 }
                 fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
                 fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
+                }
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc20.c
+++ b/verifier/reduce/osh_reduce_tc20.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : BASE_VALUE );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc21.c
+++ b/verifier/reduce/osh_reduce_tc21.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : BASE_VALUE );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc22.c
+++ b/verifier/reduce/osh_reduce_tc22.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : BASE_VALUE );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc23.c
+++ b/verifier/reduce/osh_reduce_tc23.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,21 +801,23 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
 
                 shfree(pWrk);
@@ -892,26 +898,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : BASE_VALUE );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc24.c
+++ b/verifier/reduce/osh_reduce_tc24.c
@@ -774,8 +774,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -793,21 +797,23 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
 
                 shfree(pWrk);
@@ -886,26 +892,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : BASE_VALUE );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc25.c
+++ b/verifier/reduce/osh_reduce_tc25.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -891,26 +896,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : BASE_VALUE );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc26.c
+++ b/verifier/reduce/osh_reduce_tc26.c
@@ -778,8 +778,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -797,23 +801,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,26 +897,30 @@ static int test_item8(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : BASE_VALUE );
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const_longdouble(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const_longdouble(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc27.c
+++ b/verifier/reduce/osh_reduce_tc27.c
@@ -796,8 +796,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -815,23 +819,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -916,26 +921,30 @@ static int test_item8(void)
                     while (k--) expect_value += (k % 2 ? 0 : k);
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc28.c
+++ b/verifier/reduce/osh_reduce_tc28.c
@@ -796,8 +796,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -815,23 +819,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -916,26 +921,30 @@ static int test_item8(void)
                     while (k--) expect_value += (k % 2 ? 0 : k);
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc29.c
+++ b/verifier/reduce/osh_reduce_tc29.c
@@ -796,8 +796,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -815,23 +819,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -916,26 +921,30 @@ static int test_item8(void)
                     while (k--) expect_value += (k % 2 ? 0 : k);
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc3.c
+++ b/verifier/reduce/osh_reduce_tc3.c
@@ -787,8 +787,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -811,18 +815,19 @@ static int test_item7(void)
                 log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
                                    my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                if ( in_active_set ) {
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -894,8 +899,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -913,23 +922,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -994,26 +1004,30 @@ static int test_item9(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc > 2 ? ((TYPE_VALUE)BASE_VALUE & (TYPE_VALUE)num_proc) : (TYPE_VALUE)BASE_VALUE ));
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc30.c
+++ b/verifier/reduce/osh_reduce_tc30.c
@@ -796,8 +796,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -815,23 +819,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -916,26 +921,30 @@ static int test_item8(void)
                     while (k--) expect_value += (k % 2 ? 0 : k);
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc31.c
+++ b/verifier/reduce/osh_reduce_tc31.c
@@ -796,8 +796,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -815,23 +819,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -916,26 +921,30 @@ static int test_item8(void)
                     while (k--) expect_value += (k % 2 ? 0 : k);
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc32.c
+++ b/verifier/reduce/osh_reduce_tc32.c
@@ -796,8 +796,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -815,23 +819,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -916,26 +921,30 @@ static int test_item8(void)
                     while (k--) expect_value += (k % 2 ? 0 : k);
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc33.c
+++ b/verifier/reduce/osh_reduce_tc33.c
@@ -796,8 +796,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -815,23 +819,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -916,26 +921,30 @@ static int test_item8(void)
                     while (k--) expect_value += (k % 2 ? 0 : k);
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const_longdouble(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const_longdouble(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc34.c
+++ b/verifier/reduce/osh_reduce_tc34.c
@@ -796,8 +796,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -815,23 +819,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f) buffer size = %lld\n",
-                                   my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value), (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f) buffer size = %lld\n",
+                                       my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value), (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -916,26 +921,30 @@ static int test_item8(void)
                     while (k--) expect_value += (k % 2 ? 0 : k);
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f) buffer size = %lld\n",
-                                   my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value), (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f) buffer size = %lld\n",
+                                       my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value), (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc35.c
+++ b/verifier/reduce/osh_reduce_tc35.c
@@ -715,7 +715,6 @@ static int test_item6(void)
                     log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
                     show_buffer(check_addr + show_index, show_size);
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -796,8 +795,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -815,21 +818,23 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f) buffer size = %lld\n",
-                                   my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value), (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f) buffer size = %lld\n",
+                                       my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value), (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
 
                 shfree(pWrk);
@@ -916,26 +921,30 @@ static int test_item8(void)
                     while (k--) expect_value += (k % 2 ? 0 : k);
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f) buffer size = %lld\n",
-                                   my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value), (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f) buffer size = %lld\n",
+                                       my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value), (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc36.c
+++ b/verifier/reduce/osh_reduce_tc36.c
@@ -802,8 +802,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -821,23 +825,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,26 +931,30 @@ static int test_item8(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc37.c
+++ b/verifier/reduce/osh_reduce_tc37.c
@@ -803,8 +803,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -822,23 +826,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -927,26 +932,30 @@ static int test_item8(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc38.c
+++ b/verifier/reduce/osh_reduce_tc38.c
@@ -802,8 +802,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -821,21 +825,23 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
 
                 shfree(pWrk);
@@ -926,26 +932,30 @@ static int test_item8(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc39.c
+++ b/verifier/reduce/osh_reduce_tc39.c
@@ -802,8 +802,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -821,23 +825,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,26 +931,30 @@ static int test_item8(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc4.c
+++ b/verifier/reduce/osh_reduce_tc4.c
@@ -785,8 +785,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -804,23 +808,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -892,8 +897,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -911,23 +920,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -992,26 +1002,30 @@ static int test_item9(void)
                 /* Define expected value */
                 expect_value = ( my_proc % 2 ? DEFAULT_VALUE : ( num_proc > 2 ? ((TYPE_VALUE)BASE_VALUE & (TYPE_VALUE)num_proc) : (TYPE_VALUE)BASE_VALUE ));
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc40.c
+++ b/verifier/reduce/osh_reduce_tc40.c
@@ -802,8 +802,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -821,23 +825,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
-                                   my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
+                                       my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,26 +931,30 @@ static int test_item8(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
-                                   my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
+                                       my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc41.c
+++ b/verifier/reduce/osh_reduce_tc41.c
@@ -803,8 +803,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -822,23 +826,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
-                                   my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
+                                       my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -927,26 +932,30 @@ static int test_item8(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
-                                   my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
+                                       my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc42.c
+++ b/verifier/reduce/osh_reduce_tc42.c
@@ -802,8 +802,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -821,23 +825,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
-                                   my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
+                                       my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const_longdouble(check_addr, cur_buf_size, expect_value);
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,26 +931,30 @@ static int test_item8(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const_longdouble(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
-                                   my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const_longdouble(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value);
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %Lf expected = %Lf actual = %Lf buffer size = %lld\n",
+                                       my_proc, (long double)source_value, (long double)expect_value, (long double)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const_longdouble(target_addr, cur_buf_size, expect_value);
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc43.c
+++ b/verifier/reduce/osh_reduce_tc43.c
@@ -802,8 +802,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -821,23 +825,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f)\n",
-                                   my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value));
+                    log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f)\n",
+                                       my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value));
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,26 +931,30 @@ static int test_item8(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f)\n",
-                                   my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value));
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f)\n",
+                                       my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value));
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc44.c
+++ b/verifier/reduce/osh_reduce_tc44.c
@@ -802,8 +802,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -821,23 +825,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f)\n",
-                                   my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value));
+                    log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f)\n",
+                                       my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value));
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,26 +931,30 @@ static int test_item8(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f)\n",
-                                   my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value));
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = (%6.4f, %6.4f) expected = (%6.4f, %6.4f) actual = (%6.4f, %6.4f)\n",
+                                       my_proc, carg(source_value), cabs(source_value), carg(expect_value), cabs(expect_value), carg(value), cabs(value));
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc5.c
+++ b/verifier/reduce/osh_reduce_tc5.c
@@ -809,8 +809,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -828,23 +832,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,8 +931,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -945,23 +954,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -1036,26 +1046,30 @@ static int test_item9(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc6.c
+++ b/verifier/reduce/osh_reduce_tc6.c
@@ -809,8 +809,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -828,23 +832,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,8 +931,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -945,23 +954,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -1036,26 +1046,30 @@ static int test_item9(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc7.c
+++ b/verifier/reduce/osh_reduce_tc7.c
@@ -809,8 +809,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -828,23 +832,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,8 +931,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -945,23 +954,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -1036,26 +1046,30 @@ static int test_item9(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc8.c
+++ b/verifier/reduce/osh_reduce_tc8.c
@@ -809,8 +809,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -828,23 +832,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -926,8 +931,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -945,23 +954,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -1036,26 +1046,30 @@ static int test_item9(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {

--- a/verifier/reduce/osh_reduce_tc9.c
+++ b/verifier/reduce/osh_reduce_tc9.c
@@ -810,8 +810,12 @@ static int test_item7(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -829,23 +833,24 @@ static int test_item7(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -927,8 +932,12 @@ static int test_item8(void)
                 }
                 shmem_barrier_all();
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
+
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr, source_addr, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrk, pSync);
+                }
 
                 /* Get value put by peer:
                  * These routines start the remote transfer and may return before the data
@@ -946,23 +955,24 @@ static int test_item8(void)
                     }
                 }
 
-                rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                if ( in_active_set ) {
+                    rc = (!compare_buffer_with_const(target_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
                 }
-
                 shfree(pWrk);
             } else {
                 rc = TC_SETUP_FAIL;
@@ -1037,26 +1047,30 @@ static int test_item9(void)
                     }
                 }
 
-                /* Put value to peer */
-                FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
-                rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
+                int in_active_set = check_within_active_set(0, 1, ((num_proc / 2) + (num_proc % 2)), my_proc, num_proc);
 
-                log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
-                                   my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
+                if ( in_active_set ) {
+                    /* Put value to peer */
+                    FUNC_VALUE(target_addr + (i % 2) * MAX_BUFFER_SIZE, source_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, 0, 1, ((num_proc / 2) + (num_proc % 2)), pWrkMult + (i % pWrkNum) * sys_max(MAX_BUFFER_SIZE, _SHMEM_REDUCE_MIN_WRKDATA_SIZE),  pSyncMult + (i % pSyncNum) * _SHMEM_REDUCE_SYNC_SIZE);
+                    rc = (!compare_buffer_with_const(target_addr + (i % 2) * MAX_BUFFER_SIZE, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
-                if (rc)
-                {
-                    TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
-                    int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
-                    int show_index = (odd_index > 1 ? odd_index - 2 : 0);
-                    int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+                    log_debug(OSH_TC, "my#%d source = %lld expected = %lld actual = %lld buffer size = %lld\n",
+                                       my_proc, (INT64_TYPE)source_value, (INT64_TYPE)expect_value, (INT64_TYPE)value, (INT64_TYPE)cur_buf_size);
 
-                    log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
-                    log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
-                    show_buffer(check_addr + show_index, show_size);
+                    if (rc)
+                    {
+                        TYPE_VALUE* check_addr = target_addr + (i % 2) * MAX_BUFFER_SIZE;
+                        int odd_index = compare_buffer_with_const(check_addr, cur_buf_size, &expect_value, sizeof(expect_value));
+                        int show_index = (odd_index > 1 ? odd_index - 2 : 0);
+                        int show_size = sizeof(*check_addr) * sys_min(3, cur_buf_size - odd_index - 1);
+
+                        log_debug(OSH_TC, "index of incorrect value: 0x%08X (%d)\n", odd_index - 1, odd_index - 1);
+                        log_debug(OSH_TC, "buffer interval: 0x%08X - 0x%08X\n", show_index, show_index + show_size);
+                        show_buffer(check_addr + show_index, show_size);
+                    }
+                    fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
+                    fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
                 }
-                fill_buffer((void *)(source_addr + (i % 2) * MAX_BUFFER_SIZE), cur_buf_size, (void *)&source_value, sizeof(source_value));
-                fill_buffer((void *)(target_addr + (i % 2) * MAX_BUFFER_SIZE ), cur_buf_size, (void *)&value, sizeof(value));
             }
             shfree(pWrkMult);
         } else {


### PR DESCRIPTION
Adds the --enable-active-sets configure option, which checks whether a
PE is within the active set of a reduction before making the call.