### PR TITLE
Remove -Werror from Makefile.am

### DIFF
--- a/verifier/Makefile.am
+++ b/verifier/Makefile.am
@@ -25,7 +25,7 @@ bin_PROGRAMS = oshmem_test
 lib_LIBRARIES = liboshmem_basic_tc3.a
 liboshmem_basic_tc3_a_SOURCES = basic/osh_basic_tc3_lib.c
 
-oshmem_test_CFLAGS =  $(CFLAGS) -Werror -Wall -D__LINUX__ \
+oshmem_test_CFLAGS =  $(CFLAGS) -Wall -D__LINUX__ \
 					  -I. \
 					  -I$(top_srcdir) \
 					  -I$(top_srcdir)/cmn

--- a/verifier/Makefile.am
+++ b/verifier/Makefile.am
@@ -25,7 +25,11 @@ bin_PROGRAMS = oshmem_test
 lib_LIBRARIES = liboshmem_basic_tc3.a
 liboshmem_basic_tc3_a_SOURCES = basic/osh_basic_tc3_lib.c
 
-oshmem_test_CFLAGS =  $(CFLAGS) -Wall -D__LINUX__ \
+if ENABLE_ERROR
+ERROR_FLAG = -Werror
+endif
+
+oshmem_test_CFLAGS =  $(CFLAGS) $(ERROR_FLAG) -Wall -D__LINUX__ \
 					  -I. \
 					  -I$(top_srcdir) \
 					  -I$(top_srcdir)/cmn

--- a/verifier/configure.ac
+++ b/verifier/configure.ac
@@ -51,5 +51,11 @@ AC_ARG_ENABLE([quick-tests],
 AS_IF([test "$enable_quick_tests" = "yes"], [AC_DEFINE([QUICK_TEST], [1], [Enable quick tests])], [])
 AM_CONDITIONAL([QUICK_TEST], [test "$enable_quick_tests" = "yes"])
 
+AC_ARG_ENABLE([error],
+    [AC_HELP_STRING([--enable-error],
+    [Pass the -Werror flag to treat all warnings as errors (default: enabled)])])
+AS_IF([test "$enable_error" != "no"], [AC_DEFINE([ENABLE_ERROR], [1], [Pass -Werror])], [])
+AM_CONDITIONAL([ENABLE_ERROR], [test "$enable_error" != "no"])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Many deprecated OpenSHMEM functions are included in tests-mellanox,
which produces a compiler warning in some OpenSHMEM implementations
(like SOS), but hard-setting -Werror prohibits ignoring these warnings.
Removing -Werror enables said implementations to build these tests
cleanly with -Wno-deprecated.  If -Werror is otherwise needed, it can be
set in CFLAGS at configure time.