### PR TITLE
Fix active set membership check in barrier test

### DIFF
--- a/verifier/sync/osh_sync_tc4.c
+++ b/verifier/sync/osh_sync_tc4.c
@@ -270,7 +270,7 @@ static int test_group(int start_pe, int pe_size)
     /* skip barrier if not in the group because according to spec
      * the behaviour is not defined
      */
-    if ((my_proc < start_pe) || (my_proc > start_pe + pe_size))
+    if ((my_proc < start_pe) || (my_proc >= start_pe + pe_size))
     {
         goto done;
     }


### PR DESCRIPTION
Example: start_pe = 0 and pe_size = 4, active set should include { 0, 1, 2, 3 }, but this check was giving us { 0, 1, 2, 3, 4 }.