### PR TITLE
Fix shmem_test arguments in osh_basic_tc7.c

### DIFF
--- a/verifier/basic/osh_basic_tc7.c
+++ b/verifier/basic/osh_basic_tc7.c
@@ -51,7 +51,7 @@ int osh_basic_tc7(const TE_NODE *node, int argc, const char *argv[])
         int wait_time = 0;
         //wait for pe #1 to change my variable
         //and do some important work in the while
-        while (shmem_int_test(&test_variable, SHMEM_CMP_NE, 1) && wait_time < 5000000)
+        while (shmem_int_test(&test_variable, SHMEM_CMP_EQ, 0) && wait_time < 5000000)
         {
             usleep(1000);
             wait_time += 1000;

--- a/verifier/basic/osh_basic_tc7.c
+++ b/verifier/basic/osh_basic_tc7.c
@@ -51,7 +51,7 @@ int osh_basic_tc7(const TE_NODE *node, int argc, const char *argv[])
         int wait_time = 0;
         //wait for pe #1 to change my variable
         //and do some important work in the while
-        while (shmem_int_test(&test_variable, 0, SHMEM_CMP_EQ) && wait_time < 5000000)
+        while (shmem_int_test(&test_variable, SHMEM_CMP_NE, 1) && wait_time < 5000000)
         {
             usleep(1000);
             wait_time += 1000;


### PR DESCRIPTION
This is a proposed fix for SOS issue [#791](https://github.com/Sandia-OpenSHMEM/SOS/issues/791) in reference to this comment:
https://github.com/openshmem-org/tests-mellanox/commit/50a19a296994e37d2352db0643fd056c0739e5a8#r31152661

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>