### PR TITLE
Clean up goto and fix Mac build

### DIFF
--- a/verifier/Makefile.am
+++ b/verifier/Makefile.am
@@ -21,10 +21,6 @@ EXTRA_DIST=autogen.sh
 
 bin_PROGRAMS = oshmem_test
 
-# This lib is used for basic:tc3
-lib_LIBRARIES = liboshmem_basic_tc3.a
-liboshmem_basic_tc3_a_SOURCES = basic/osh_basic_tc3_lib.c
-
 if ENABLE_ERROR
 ERROR_FLAG = -Werror
 endif
@@ -34,7 +30,7 @@ oshmem_test_CFLAGS =  $(CFLAGS) $(ERROR_FLAG) -Wall -D__LINUX__ \
 					  -I$(top_srcdir) \
 					  -I$(top_srcdir)/cmn
 
-oshmem_test_LDFLAGS = $(LDFLAGS) -L. -loshmem_basic_tc3 -lm
+oshmem_test_LDFLAGS = $(LDFLAGS) -L. -lm
 
 noinst_HEADERS = \
 	osh_tests.h \
@@ -114,6 +110,7 @@ oshmem_test_SOURCES = \
 	basic/osh_basic_tc7.c \
 	basic/osh_basic_tc8.c \
 	basic/osh_basic_tc9.c \
+	basic/osh_basic_tc3_lib.c \
 	data/osh_data.c \
 	data/osh_data_tc1.c \
 	data/osh_data_tc2.c \

--- a/verifier/Makefile.am
+++ b/verifier/Makefile.am
@@ -25,7 +25,7 @@ if ENABLE_ERROR
 ERROR_FLAG = -Werror
 endif
 
-oshmem_test_CFLAGS =  $(CFLAGS) $(ERROR_FLAG) -Wall -D__LINUX__ \
+oshmem_test_CFLAGS =  $(CFLAGS) $(ERROR_FLAG) -Wall \
 					  -I. \
 					  -I$(top_srcdir) \
 					  -I$(top_srcdir)/cmn

--- a/verifier/basic/osh_basic_tc3.c
+++ b/verifier/basic/osh_basic_tc3.c
@@ -474,6 +474,7 @@ static int test_shmem_ptr()
     int *ptr;
     int *pdata;
     int i;
+    int ret = TC_PASS;
 
     pdata = (int *)shmalloc(5678);
     foo = my_pe;
@@ -487,22 +488,23 @@ static int test_shmem_ptr()
         ptr = shmem_ptr(&foo, i);
         if (ptr) {
             log_debug(OSH_TC, "%d: shmem_ptr(static=%p, dst=%d) = %p, val=%d\n", my_pe, &foo, i, ptr, *ptr);
-            if (*ptr != i)
-                goto fail;
+            if (*ptr != i) {
+                ret = TC_FAIL;
+                break;
+            }
         }
         ptr = shmem_ptr(pdata, i);
         if (ptr) {
             log_debug(OSH_TC, "%d: shmem_ptr(heap=%p, dst=%d) = %p, val=%d\n", my_pe, pdata, i, ptr, *ptr);
-            if (*ptr != i)
-                goto fail;
+            if (*ptr != i) {
+                ret = TC_FAIL;
+                break;
+            }
         }
     }
 
     shfree(pdata);
-    return TC_PASS;
-fail:
-    shfree(pdata);
-    return TC_FAIL;
+    return ret;
 }
 
 static int test_max_size(void)

--- a/verifier/basic/osh_basic_tc7.c
+++ b/verifier/basic/osh_basic_tc7.c
@@ -36,14 +36,7 @@ int osh_basic_tc7(const TE_NODE *node, int argc, const char *argv[])
 
     if (num_of_pes < 2)
     {
-        rc = TC_SETUP_FAIL;
-        goto FreeMemory;
-    }
-
-    //This test is for 2 ranks only
-    if (me > 1)
-    {
-        goto FreeMemory;
+        return TC_SETUP_FAIL;
     }
 
     if (0 == me)
@@ -63,14 +56,14 @@ int osh_basic_tc7(const TE_NODE *node, int argc, const char *argv[])
             rc = TC_FAIL;
         }
     }
-    else
+    else if (1 == me)
     {
         shmem_int_put(&test_variable, &value_to_set, 1, 0);
     }
 
-FreeMemory:
     shmem_barrier_all();
 
     return rc;
 }
+
 

--- a/verifier/cmn/aopt.c
+++ b/verifier/cmn/aopt.c
@@ -34,7 +34,7 @@
 
 #if defined(_AOPT_CONF_TRACE) && (_AOPT_CONF_TRACE==TRUE)
     #if defined(__KERNEL__)
-        #if defined(__LINUX__)
+        #if defined(__linux__)
             #define AOPT_TRACE(fmt, ...)  printk(fmt, ##__VA_ARGS__)
         #else
             #define AOPT_TRACE(fmt, ...)  DbgPrint(fmt, ##__VA_ARGS__)

--- a/verifier/cmn/osh_cmn.c
+++ b/verifier/cmn/osh_cmn.c
@@ -344,6 +344,7 @@ void spin_wait(unsigned long usec)
 
 void get_mstat(TE_MEM *mstat)
 {
+#ifdef __linux__
     FILE *f = NULL;
     char temp_buf[256];
 
@@ -370,6 +371,10 @@ void get_mstat(TE_MEM *mstat)
             fclose(f);
         }
     }
+#else
+    mstat->vm_size = -1;
+    mstat->vm_rss = -1;
+#endif
 }
 
 char * get_rc_string(int rc){

--- a/verifier/cmn/osh_cmn.h
+++ b/verifier/cmn/osh_cmn.h
@@ -65,7 +65,7 @@ static INLINE int sys_time(struct timeval *tv)
 {
     int status = 0;
 
-#if defined(__LINUX__)
+#if _POSIX_VERSION >= 200112L
     status = gettimeofday(tv, NULL);
 #else
     time_t t = time(NULL);
@@ -81,7 +81,6 @@ static INLINE uint64_t sys_rdtsc(void)
 {
     unsigned long long int result=0;
 
-#if defined(__LINUX__)
     #if defined(__i386__)
         __asm volatile(".byte 0x0f, 0x31" : "=A" (result) : );
 
@@ -108,7 +107,6 @@ static INLINE uint64_t sys_rdtsc(void)
         result = result|lo;
 
     #endif
-#endif /* __LINUX__ */
 
     return (result);
 }

--- a/verifier/cmn/osh_def.h
+++ b/verifier/cmn/osh_def.h
@@ -16,6 +16,7 @@
 #ifndef _OSH_DEF_H_
 #define _OSH_DEF_H_
 
+#include "config.h"
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -31,16 +32,11 @@
 #include <complex.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#if defined(__LINUX__)
+#ifdef HAVE_UNISTD_H
+    #include <unistd.h>
     #include <errno.h>
     #include <stdint.h>
-    #include <inttypes.h>
-    #include <unistd.h>
     #include <sys/time.h>
-    #include <sys/socket.h>
-    #include <sys/ioctl.h>
-    #include <netinet/in.h>
-    #include <arpa/inet.h>
     #include <pthread.h>
 #else
     #include <windows.h>
@@ -88,20 +84,14 @@ extern "C" {
  *      this check may not work under all compilers.
  */
 /** @{ */
-typedef unsigned char  UINT8_TYPE;      /**< 8-bit  unsigned integer */
-typedef char  INT8_TYPE;                /**< 8-bit  signed integer */
-typedef unsigned short UINT16_TYPE;     /**< 16-bit unsigned integer */
-typedef short INT16_TYPE;               /**< 16-bit signed integer */
-typedef unsigned long  UINT32_TYPE;     /**< 32-bit unsigned integer */
-typedef long  INT32_TYPE;               /**< 32-bit signed integer */
-
-#if defined(__LINUX__)
-    typedef unsigned long long  UINT64_TYPE;    /**< 64-bit unsigned types (compiler dependant). */
-    typedef long long           INT64_TYPE;     /**< 64-bit signed types (compiler dependant). */
-#else
-    typedef unsigned __int64    UINT64_TYPE;    /**< 64-bit unsigned types (compiler dependant). */
-    typedef __int64             INT64_TYPE;     /**< 64-bit signed types (compiler dependant). */
-#endif
+typedef uint8_t   UINT8_TYPE;                   /**< 8-bit  unsigned integer */
+typedef int8_t    INT8_TYPE;                    /**< 8-bit  signed integer */
+typedef uint16_t  UINT16_TYPE;                  /**< 16-bit unsigned integer */
+typedef int16_t   INT16_TYPE;                   /**< 16-bit signed integer */
+typedef uint32_t  UINT32_TYPE;                  /**< 32-bit unsigned integer */
+typedef int32_t   INT32_TYPE;                   /**< 32-bit signed integer */
+typedef uint64_t  UINT64_TYPE;                  /**< 64-bit unsigned types */
+typedef int64_t   INT64_TYPE;                   /**< 64-bit signed types */
 
 #pragma pack( push, 1 )
 typedef struct _DATA128_TYPE

--- a/verifier/configure.ac
+++ b/verifier/configure.ac
@@ -12,6 +12,7 @@ AM_PROG_CC_C_O
 AC_PROG_LIBTOOL
 AM_MAINTAINER_MODE
 AC_CONFIG_MACRO_DIR([m4])
+AC_CONFIG_HEADERS([cmn/config.h])
 
 if [ $CC --version | grep icc ]; then
     CFLAGS="$CFLAGS -wd188,981,1419,810"
@@ -73,5 +74,6 @@ AC_CHECK_DECLS([shmem_uint_atomic_and, shmem_ulong_atomic_and, shmem_ulonglong_a
                 shmem_uint_atomic_xor, shmem_ulong_atomic_xor, shmem_ulonglong_atomic_xor],
     [], [], [#include "shmem.h"])
 
+AC_CHECK_HEADERS([unistd.h])
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/verifier/data/osh_data_tc40.c
+++ b/verifier/data/osh_data_tc40.c
@@ -121,7 +121,7 @@ int osh_data_tc40(const TE_NODE *node, int argc, const char *argv[])
 static int wait_for_value(int *shmem_addr, int value)
 {
     struct timeval tv;
-    __time_t deadline;
+    time_t deadline;
 
     gettimeofday(&tv, NULL);
     deadline = tv.tv_sec + TIMEOUT_SEC; /* 5 min */

--- a/verifier/osh_exec.c
+++ b/verifier/osh_exec.c
@@ -72,7 +72,7 @@ static const AOPT_DESC  self_opt_desc[] =
         'i', AOPT_OPTARG,   aopt_set_literal( 0 ),    aopt_set_string( "info" ),
             "Display list of supported tasks [suite|case] (default: suite)."
     },
-#if defined(__LINUX__)
+#if defined(__linux__) || defined(__APPLE__)
     {
         'c', AOPT_NOARG,   aopt_set_literal( 0 ),    aopt_set_string( "no-colour" ),
             "Define output in monochrome view."
@@ -317,16 +317,16 @@ static int __do_exec( const TE_NODE* node, const AOPT_OBJECT* opt_obj, int argc,
                         }
                     }
                     log_info(OSH_STD, "%s%-6.6s%s %-10.10s %-14.14s %s\n",
-#if defined(__LINUX__)
+#if defined(__linux__) || defined(__APPLE__)
                                             ( opt_obj && aopt_check(opt_obj, 'c') ? "" : (!ignored && !skipped ? get_rc_color(rc) : ( !skipped ? "\e[33m" : "\e[34m")) ),
 #else
-    ""
+    "",
 #endif
                                             (!ignored && !skipped ? get_rc_string(rc) : ( !skipped ? "IGNORE" : "SKIP")),
-#if defined(__LINUX__)
+#if defined(__linux__) || defined(__APPLE__)
                                             ( opt_obj && aopt_check(opt_obj, 'c') ? "" : "\e[0m" ),
 #else
-    ""
+    "",
 #endif
                                             cur_tst_node->name,
                                             cur_tcs_node->name,


### PR DESCRIPTION
Several patches to remove usage of `goto` where it's not necessary and also to get the build working on Mac again.