### PR TITLE
Updated macro and variable decls to fit to POSIX and C89

### DIFF
--- a/verifier/Makefile.am
+++ b/verifier/Makefile.am
@@ -29,7 +29,7 @@ if ENABLE_ERROR
 ERROR_FLAG = -Werror
 endif
 
-oshmem_test_CFLAGS =  $(CFLAGS) $(ERROR_FLAG) -Wall -D__LINUX__ \
+oshmem_test_CFLAGS =  $(CFLAGS) $(ERROR_FLAG) -Wall -D__UNIX__ \
 					  -I. \
 					  -I$(top_srcdir) \
 					  -I$(top_srcdir)/cmn

--- a/verifier/cmn/aopt.c
+++ b/verifier/cmn/aopt.c
@@ -34,7 +34,7 @@
 
 #if defined(_AOPT_CONF_TRACE) && (_AOPT_CONF_TRACE==TRUE)
     #if defined(__KERNEL__)
-        #if defined(__LINUX__)
+        #if defined(__UNIX__)
             #define AOPT_TRACE(fmt, ...)  printk(fmt, ##__VA_ARGS__)
         #else
             #define AOPT_TRACE(fmt, ...)  DbgPrint(fmt, ##__VA_ARGS__)

--- a/verifier/cmn/osh_cmn.h
+++ b/verifier/cmn/osh_cmn.h
@@ -65,7 +65,7 @@ static INLINE int sys_time(struct timeval *tv)
 {
     int status = 0;
 
-#if defined(__LINUX__)
+#if defined(__UNIX__)
     status = gettimeofday(tv, NULL);
 #else
     time_t t = time(NULL);
@@ -81,7 +81,7 @@ static INLINE uint64_t sys_rdtsc(void)
 {
     unsigned long long int result=0;
 
-#if defined(__LINUX__)
+#if defined(__UNIX__)
     #if defined(__i386__)
         __asm volatile(".byte 0x0f, 0x31" : "=A" (result) : );
 
@@ -108,7 +108,7 @@ static INLINE uint64_t sys_rdtsc(void)
         result = result|lo;
 
     #endif
-#endif /* __LINUX__ */
+#endif /* __UNIX__ */
 
     return (result);
 }

--- a/verifier/cmn/osh_def.h
+++ b/verifier/cmn/osh_def.h
@@ -31,7 +31,7 @@
 #include <complex.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#if defined(__LINUX__)
+#if defined(__UNIX__)
     #include <errno.h>
     #include <stdint.h>
     #include <inttypes.h>
@@ -95,7 +95,7 @@ typedef short INT16_TYPE;               /**< 16-bit signed integer */
 typedef unsigned long  UINT32_TYPE;     /**< 32-bit unsigned integer */
 typedef long  INT32_TYPE;               /**< 32-bit signed integer */
 
-#if defined(__LINUX__)
+#if defined(__UNIX__)
     typedef unsigned long long  UINT64_TYPE;    /**< 64-bit unsigned types (compiler dependant). */
     typedef long long           INT64_TYPE;     /**< 64-bit signed types (compiler dependant). */
 #else

--- a/verifier/cmn/rnd_mt.h
+++ b/verifier/cmn/rnd_mt.h
@@ -20,9 +20,11 @@ typedef struct random_mt_state_t{
 
 /* Initialize the generator from a seed */
 void initialize_mt_generator(int seed, random_mt_state_t *state) {
+    int i;
+
     state->index = 0;
     state->MT[0] = seed;
-    for (int i = 1;  i < 624; i++) { // loop over each other element
+    for (i = 1;  i < 624; i++) { // loop over each other element
         state->MT[i] = LAST_32_BITS(1812433253 * (state->MT[i-1] ^ ((state->MT[i-1]) >> 30)) + i); // 0x6c078965
     }
 }
@@ -30,7 +32,9 @@ void initialize_mt_generator(int seed, random_mt_state_t *state) {
 /* Generate an array of 624 untempered numbers */
 void generate_numbers(random_mt_state_t *state)
 {
-    for (int i = 0; i<624; i++) {
+    int i;
+
+    for (i = 0; i<624; i++) {
         uint32_t y = (state->MT[i] & 0x80000000)                      // bit 31 (32nd bit) of MT[i]
             + (state->MT[(i+1) % 624] & 0x7fffffff);   // bits 0-30 (first 31 bits) of MT[...]
         state->MT[i] = state->MT[(i + 397) % 624] ^ (y >> 1);

--- a/verifier/osh_exec.c
+++ b/verifier/osh_exec.c
@@ -72,7 +72,7 @@ static const AOPT_DESC  self_opt_desc[] =
         'i', AOPT_OPTARG,   aopt_set_literal( 0 ),    aopt_set_string( "info" ),
             "Display list of supported tasks [suite|case] (default: suite)."
     },
-#if defined(__LINUX__)
+#if defined(__UNIX__)
     {
         'c', AOPT_NOARG,   aopt_set_literal( 0 ),    aopt_set_string( "no-colour" ),
             "Define output in monochrome view."
@@ -317,13 +317,13 @@ static int __do_exec( const TE_NODE* node, const AOPT_OBJECT* opt_obj, int argc,
                         }
                     }
                     log_info(OSH_STD, "%s%-6.6s%s %-10.10s %-14.14s %s\n",
-#if defined(__LINUX__)
+#if defined(__UNIX__)
                                             ( opt_obj && aopt_check(opt_obj, 'c') ? "" : (!ignored && !skipped ? get_rc_color(rc) : ( !skipped ? "\e[33m" : "\e[34m")) ),
 #else
     ""
 #endif
                                             (!ignored && !skipped ? get_rc_string(rc) : ( !skipped ? "IGNORE" : "SKIP")),
-#if defined(__LINUX__)
+#if defined(__UNIX__)
                                             ( opt_obj && aopt_check(opt_obj, 'c') ? "" : "\e[0m" ),
 #else
     ""


### PR DESCRIPTION
- macro __LINUX__ is replaced by __UNIX__
- removed variable declarations from ```for``` loop

fixes #39

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>