### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ tests-mellanox
 ### Mellanox Vendor Tests for OpenSHMEM API
 
 * Download and Install HPCx package with OpenSHMEM framework from http://bgate.mellanox.com/products/hpcx/
-* Check README.txt file from a HPCx package for instructions
+* Check README.txt file from an HPCx package for instructions
 * Compile and run test kit as following
 * In the howto instruction 'module load hpcx' makes visible oshcc compiler needed to build OpenSHMEM application
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ tests-mellanox
 ### Mellanox Vendor Tests for OpenSHMEM API
 
 * Download and Install HPCx package with OpenSHMEM framework from http://bgate.mellanox.com/products/hpcx/
-* Check http://bgate.mellanox.com/products/hpcx/README.txt for instructions
+* Check README.txt file from a specific HPCX package for instructions
 * Compile and run test kit as following
 * In the howto instruction 'module load hpcx' makes visible oshcc compiler needed to build OpenSHMEM application
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ tests-mellanox
 ### Mellanox Vendor Tests for OpenSHMEM API
 
 * Download and Install HPCx package with OpenSHMEM framework from http://bgate.mellanox.com/products/hpcx/
-* Check README.txt file from a specific HPCX package for instructions
+* Check README.txt file from a HPCx package for instructions
 * Compile and run test kit as following
 * In the howto instruction 'module load hpcx' makes visible oshcc compiler needed to build OpenSHMEM application
 


### PR DESCRIPTION
The current link to README.txt is unavailable. Just replace it by the wording:
`Check README.txt file from a specific HPCX package for instructions`
that covers all releases/packages