### PR TITLE
Create a Github Actions based CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on: [push]
+
+env:
+  HPCX_PKG_NAME: hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu18.04-x86_64
+  HPCX_PKG_LINK: http://www.mellanox.com/downloads/hpc/hpc-x/v2.5
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Get HPCX
+      run: wget "${HPCX_PKG_LINK}/${HPCX_PKG_NAME}.tbz" -P /tmp
+    - name: Unpack HPCX
+      run: cd /tmp && tar xjf "${HPCX_PKG_NAME}.tbz"
+    - uses: actions/checkout@v1
+    - name: Build
+      run: |
+        source /tmp/${HPCX_PKG_NAME}/hpcx-init.sh
+        hpcx_load
+        export SHMEM_HOME=$HPCX_MPI_DIR
+        export CC=''
+        cd verifier
+        ./autogen.sh
+        ./configure --prefix=$PWD/install
+        make -j`nproc` install


### PR DESCRIPTION
Build steps took from
http://bgate.mellanox.com/jenkins/job/OpenShmem-pr__published_from_mellanox_lab/.
Original Jenkins's job uses the internal HPCX daily env module. To have it I pull relevant GA package.