### PR TITLE
SHMEM: verifier-analysis-tc1: FAIL analysis cycles Lost cycles check

### DIFF
--- a/verifier/cmn/osh_cmn.h
+++ b/verifier/cmn/osh_cmn.h
@@ -105,7 +105,9 @@ static INLINE uint64_t sys_rdtsc(void)
         result = hi;
         result = result<<32;
         result = result|lo;
-
+    #elif defined(__aarch64__)
+        asm volatile("isb" : : : "memory");
+        asm volatile("mrs %0, cntvct_el0" : "=r" (result));
     #endif
 
     return (result);


### PR DESCRIPTION
- fixed issue on ARM system: SHMEM: verifier-analysis-tc1: FAIL
  analysis cycles Lost cycles check
- added CPU clock read implementation for ARM64 platform