### PR TITLE
DATA: Fix put tests

### DIFF
--- a/verifier/cmn/osh_cmn.c
+++ b/verifier/cmn/osh_cmn.c
@@ -14,22 +14,6 @@
 
 #include "shmem.h"
 
-static int _put_completion_flag = PUT_IN_PROGRESS;
-
-void wait_for_put_completion(int pe, double timeout)
-{
-    double time_start = sys_gettime();
-    shmem_fence();
-    shmem_int_p(&_put_completion_flag,PUT_COMPLETED,pe);
-    while (PUT_COMPLETED != _put_completion_flag &&
-           (sys_gettime()-time_start < timeout*1e6)){
-        do_progress();
-    }
-
-    /* reset completion flag for next usages */
-    _put_completion_flag = PUT_IN_PROGRESS;
-}
-
 const TE_NODE* find_node(const TE_NODE* node_set, const char *name)
 {
     const TE_NODE* node = NULL;

--- a/verifier/cmn/osh_cmn.h
+++ b/verifier/cmn/osh_cmn.h
@@ -319,7 +319,6 @@ static inline void do_progress(void)
 #endif
 }
 
-void wait_for_put_completion(int pe, double timeout);
 BOOL compare_buffer(unsigned char *buf1, unsigned char *buf2, size_t size, size_t* odd_pos);
 BOOL compare_longdouble_buffers(long double *buf1, long double *buf2, size_t size, size_t* odd_pos);
 void random_buffer(unsigned char *buf, size_t size);

--- a/verifier/data/osh_data_tc10.c
+++ b/verifier/data/osh_data_tc10.c
@@ -109,11 +109,9 @@ static int test_item1(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -171,11 +169,9 @@ static int test_item2(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -220,6 +216,10 @@ static int test_item3(void)
         /* Set my value */
         my_value = (-1);
         *shmem_addr = my_value;
+
+        /* This guarantees that PE set initial value before peer change one */
+        shmem_barrier_all();
+
         for (i = 0; i < COUNT_VALUE; i++)
         {
             /* Define peer and it value */
@@ -229,17 +229,12 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * STEP_VALUE);
 
-            /* This guarantees that PE set initial value before peer change one */
-            shmem_barrier_all();
-
             /* Write value to peer */
             FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our value is already updated by peer */
+            shmem_barrier_all();
+
             value = *shmem_addr;
 
             rc = (expect_value == value ? TC_PASS : TC_FAIL);

--- a/verifier/data/osh_data_tc11.c
+++ b/verifier/data/osh_data_tc11.c
@@ -109,11 +109,9 @@ static int test_item1(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (sys_fcompare(expect_value, value) ? TC_PASS : TC_FAIL);
@@ -171,11 +169,9 @@ static int test_item2(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (sys_fcompare(expect_value, value) ? TC_PASS : TC_FAIL);
@@ -220,6 +216,10 @@ static int test_item3(void)
         /* Set my value */
         my_value = (-1);
         *shmem_addr = my_value;
+
+        /* This guarantees that PE set initial value before peer change one */
+        shmem_barrier_all();
+
         for (i = 0; i < COUNT_VALUE; i++)
         {
             /* Define peer and it value */
@@ -229,17 +229,12 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * STEP_VALUE);
 
-            /* This guarantees that PE set initial value before peer change one */
-            shmem_barrier_all();
-
             /* Write value to peer */
             FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our value is already updated by peer */
+            shmem_barrier_all();
+
             value = *shmem_addr;
 
             rc = (sys_fcompare(expect_value, value) ? TC_PASS : TC_FAIL);

--- a/verifier/data/osh_data_tc12.c
+++ b/verifier/data/osh_data_tc12.c
@@ -109,11 +109,9 @@ static int test_item1(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (sys_fcompare(expect_value, value) ? TC_PASS : TC_FAIL);
@@ -171,11 +169,9 @@ static int test_item2(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (sys_fcompare(expect_value, value) ? TC_PASS : TC_FAIL);
@@ -220,6 +216,10 @@ static int test_item3(void)
         /* Set my value */
         my_value = (-1);
         *shmem_addr = my_value;
+
+        /* This guarantees that PE set initial value before peer change one */
+        shmem_barrier_all();
+
         for (i = 0; i < COUNT_VALUE; i++)
         {
             /* Define peer and it value */
@@ -229,17 +229,12 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * STEP_VALUE);
 
-            /* This guarantees that PE set initial value before peer change one */
-            shmem_barrier_all();
-
             /* Write value to peer */
             FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our value is already updated by peer */
+            shmem_barrier_all();
+
             value = *shmem_addr;
 
             rc = (sys_fcompare(expect_value, value) ? TC_PASS : TC_FAIL);

--- a/verifier/data/osh_data_tc13.c
+++ b/verifier/data/osh_data_tc13.c
@@ -109,11 +109,9 @@ static int test_item1(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -171,11 +169,9 @@ static int test_item2(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -220,6 +216,10 @@ static int test_item3(void)
         /* Set my value */
         my_value = (-1);
         *shmem_addr = my_value;
+
+        /* This guarantees that PE set initial value before peer change one */
+        shmem_barrier_all();
+
         for (i = 0; i < COUNT_VALUE; i++)
         {
             /* Define peer and it value */
@@ -229,17 +229,12 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * STEP_VALUE);
 
-            /* This guarantees that PE set initial value before peer change one */
-            shmem_barrier_all();
-
             /* Write value to peer */
             FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our value is already updated by peer */
+            shmem_barrier_all();
+
             value = *shmem_addr;
 
             rc = (expect_value == value ? TC_PASS : TC_FAIL);

--- a/verifier/data/osh_data_tc14.c
+++ b/verifier/data/osh_data_tc14.c
@@ -109,11 +109,9 @@ static int test_item1(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (sys_fcompare(expect_value, value) ? TC_PASS : TC_FAIL);
@@ -171,11 +169,9 @@ static int test_item2(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (sys_fcompare(expect_value, value) ? TC_PASS : TC_FAIL);
@@ -220,6 +216,10 @@ static int test_item3(void)
         /* Set my value */
         my_value = (-1);
         *shmem_addr = my_value;
+
+        /* This guarantees that PE set initial value before peer change one */
+        shmem_barrier_all();
+
         for (i = 0; i < COUNT_VALUE; i++)
         {
             /* Define peer and it value */
@@ -229,17 +229,12 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * STEP_VALUE);
 
-            /* This guarantees that PE set initial value before peer change one */
-            shmem_barrier_all();
-
             /* Write value to peer */
             FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our value is already updated by peer */
+            shmem_barrier_all();
+
             value = *shmem_addr;
 
             rc = (sys_fcompare(expect_value, value) ? TC_PASS : TC_FAIL);

--- a/verifier/data/osh_data_tc23.c
+++ b/verifier/data/osh_data_tc23.c
@@ -156,11 +156,10 @@ static int test_item1(void)
         /* Get value from peer */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
+
+        /* Get value put by peer */
         value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -215,14 +214,12 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
+
+        /* Get value put by peer */
         value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -283,14 +280,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -370,14 +364,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -454,14 +445,11 @@ static int test_item5(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc24.c
+++ b/verifier/data/osh_data_tc24.c
@@ -151,14 +151,11 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
@@ -210,14 +207,11 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
@@ -277,14 +271,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -364,14 +355,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -448,14 +436,11 @@ static int test_item5(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc25.c
+++ b/verifier/data/osh_data_tc25.c
@@ -151,15 +151,13 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -210,14 +208,11 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
@@ -277,14 +272,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -364,14 +356,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -448,14 +437,11 @@ static int test_item5(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc26.c
+++ b/verifier/data/osh_data_tc26.c
@@ -151,14 +151,11 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
@@ -210,15 +207,13 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -277,14 +272,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -364,14 +356,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -448,14 +437,11 @@ static int test_item5(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc27.c
+++ b/verifier/data/osh_data_tc27.c
@@ -151,15 +151,13 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (sys_fcompare(expect_value, *shmem_addr) ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%Lf) peer(#%d:%Lf) expected = %Lf buffer size = %lld\n",
@@ -210,15 +208,13 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (sys_fcompare(expect_value, *shmem_addr) ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%Lf) peer(#%d:%Lf) expected = %Lf buffer size = %lld\n",
@@ -277,14 +273,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -364,14 +357,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -448,14 +438,11 @@ static int test_item5(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc28.c
+++ b/verifier/data/osh_data_tc28.c
@@ -151,15 +151,13 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (sys_fcompare(expect_value, *shmem_addr) ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%Lf) peer(#%d:%Lf) expected = %Lf buffer size = %lld\n",
@@ -210,15 +208,13 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (sys_fcompare(expect_value, *shmem_addr) ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%Lf) peer(#%d:%Lf) expected = %Lf buffer size = %lld\n",
@@ -277,14 +273,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -364,14 +357,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -448,14 +438,11 @@ static int test_item5(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc29.c
+++ b/verifier/data/osh_data_tc29.c
@@ -151,15 +151,13 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -210,15 +208,13 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -277,14 +273,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -364,14 +357,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -448,14 +438,11 @@ static int test_item5(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc30.c
+++ b/verifier/data/osh_data_tc30.c
@@ -151,15 +151,13 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (sys_fcompare(expect_value, *shmem_addr) ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%Lf) peer(#%d:%Lf) expected = %Lf buffer size = %lld\n",
@@ -210,15 +208,13 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (sys_fcompare(expect_value, *shmem_addr) ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%Lf) peer(#%d:%Lf) expected = %Lf buffer size = %lld\n",
@@ -277,14 +273,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const_longdouble(shmem_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
@@ -364,14 +357,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const_longdouble(shmem_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 
@@ -448,14 +438,11 @@ static int test_item5(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const_longdouble(shmem_addr, cur_buf_size, expect_value) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc32.c
+++ b/verifier/data/osh_data_tc32.c
@@ -171,12 +171,10 @@ static int test_item1(void)
         /* Put value to peer */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -230,11 +228,10 @@ static int test_item2(void)
         /* Put value to peer */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-		wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
+
+        /* Get value put by peer */
 		value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -281,12 +278,10 @@ static int test_item3(void)
         /* Put value to peer */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -348,11 +343,8 @@ static int test_item4(void)
             /* Put value to peer */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -516,11 +508,8 @@ static int test_item6(void)
             /* Put value to peer */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc36.c
+++ b/verifier/data/osh_data_tc36.c
@@ -142,15 +142,13 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -201,15 +199,13 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -268,14 +264,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -355,14 +348,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc37.c
+++ b/verifier/data/osh_data_tc37.c
@@ -142,15 +142,13 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -201,15 +199,13 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",
@@ -268,14 +264,11 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = peer_value;
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -355,14 +348,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc38.c
+++ b/verifier/data/osh_data_tc38.c
@@ -144,14 +144,13 @@ static int test_item1(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
+
+        /* Get value put by peer */
         value = *shmem_addr;
 
         rc = (compare_buffer((unsigned char*)&expect_value, (unsigned char*)&value, sizeof(value), NULL) ? TC_PASS : TC_FAIL);
@@ -209,14 +208,13 @@ static int test_item2(void)
         /* This guarantees that PE set initial value before peer change one */
         shmem_barrier_all();
 
-        /* Get value from peer */
+        /* Update peer value */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
+
+        /* Get value put by peer */
         value = *shmem_addr;
 
         rc = (compare_buffer((unsigned char*)&expect_value, (unsigned char*)&value, sizeof(value), NULL) ? TC_PASS : TC_FAIL);
@@ -280,14 +278,11 @@ static int test_item3(void)
             /* Define expected value */
             memcpy(&expect_value, &peer_value, sizeof(peer_value));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 
@@ -370,14 +365,11 @@ static int test_item4(void)
             /* Define expected value */
             expect_value.field1 = (my_proc % 2 ? 1 : -1) * (i * (MAX_VALUE / __cycle_count));
 
-            /* Get value put by peer */
+            /* Update peer value */
             FUNC_VALUE(shmem_addr, send_addr, cur_buf_size, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our and peer values are already updated */
+            shmem_barrier_all();
 
             rc = (!compare_buffer_with_const(shmem_addr, cur_buf_size, &expect_value, sizeof(expect_value)) ? TC_PASS : TC_FAIL);
 

--- a/verifier/data/osh_data_tc8.c
+++ b/verifier/data/osh_data_tc8.c
@@ -109,11 +109,9 @@ static int test_item1(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
 
@@ -170,11 +168,9 @@ static int test_item2(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -219,6 +215,10 @@ static int test_item3(void)
         /* Set my value */
         my_value = (-1);
         *shmem_addr = my_value;
+
+        /* This guarantees that PE set initial value before peer change one */
+        shmem_barrier_all();
+
         for (i = 0; i < COUNT_VALUE; i++)
         {
             /* Define peer and it value */
@@ -228,17 +228,12 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * STEP_VALUE);
 
-            /* This guarantees that PE set initial value before peer change one */
-            shmem_barrier_all();
-
             /* Write value to peer */
             FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our value is already updated by peer */
+            shmem_barrier_all();
+
             value = *shmem_addr;
 
             rc = (expect_value == value ? TC_PASS : TC_FAIL);

--- a/verifier/data/osh_data_tc9.c
+++ b/verifier/data/osh_data_tc9.c
@@ -109,11 +109,9 @@ static int test_item1(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -171,11 +169,9 @@ static int test_item2(void)
         /* Write value to peer */
         FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+        /* This guarantees that our value is already updated by peer */
+        shmem_barrier_all();
+
         value = *shmem_addr;
 
         rc = (expect_value == value ? TC_PASS : TC_FAIL);
@@ -220,6 +216,10 @@ static int test_item3(void)
         /* Set my value */
         my_value = (-1);
         *shmem_addr = my_value;
+
+        /* This guarantees that PE set initial value before peer change one */
+        shmem_barrier_all();
+
         for (i = 0; i < COUNT_VALUE; i++)
         {
             /* Define peer and it value */
@@ -229,17 +229,12 @@ static int test_item3(void)
             /* Define expected value */
             expect_value = (my_proc % 2 ? 1 : -1) * (i * STEP_VALUE);
 
-            /* This guarantees that PE set initial value before peer change one */
-            shmem_barrier_all();
-
             /* Write value to peer */
             FUNC_VALUE(shmem_addr, peer_value, peer_proc);
 
-            /* Get value put by peer:
-             * These routines start the remote transfer and may return before the data
-             * is delivered to the remote PE
-             */
-            wait_for_put_completion(peer_proc,10 /* wait for 10 secs */);
+            /* This guarantees that our value is already updated by peer */
+            shmem_barrier_all();
+
             value = *shmem_addr;
 
             rc = (expect_value == value ? TC_PASS : TC_FAIL);

--- a/verifier/nbi/osh_nbi_tc2.c
+++ b/verifier/nbi/osh_nbi_tc2.c
@@ -85,14 +85,11 @@ static int test_item1(void)
 
         /* Put value to peer */
         FUNC_VALUE(shmem_addr, &peer_value, 1, peer_proc);
-        shmem_quiet();
 
-        /* Get value put by peer:
-         * These routines start the remote transfer and may return before the data
-         * is delivered to the remote PE
-         */
-        wait_for_put_completion(peer_proc, 10 /* wait for 10 secs */);
+        /* This guarantees that our and peer values are already updated */
+        shmem_barrier_all();
 
+        /* Get value put by peer */
         rc = (expect_value == *shmem_addr ? TC_PASS : TC_FAIL);
 
         log_debug(OSH_TC, "my(#%d:%lld) peer(#%d:%lld) expected = %lld buffer size = %lld\n",


### PR DESCRIPTION
Need to ensure that local PE value is updated before comparing it with expected value.
Tests fail with more intrusive (strong) fence, because they are waiting 